### PR TITLE
Fix otg

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -49,7 +49,7 @@ TARGET_HW_DISK_ENCRYPTION := true
 
 # Kernel
 BOARD_KERNEL_BASE := 0x00000000
-BOARD_KERNEL_CMDLINE := androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 sched_enable_hmp=1 sched_enable_power_aware=1 service_locator.enable=1 swiotlb=2048 androidboot.selinux=permissive
+BOARD_KERNEL_CMDLINE := androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 sched_enable_hmp=1 sched_enable_power_aware=1 service_locator.enable=1 swiotlb=2048 androidboot.usbcontroller=a800000.dwc3  androidboot.selinux=permissive
 BOARD_KERNEL_PAGESIZE := 4096
 BOARD_KERNEL_TAGS_OFFSET := 0x00000100
 BOARD_RAMDISK_OFFSET := 0x01000000

--- a/recovery.fstab
+++ b/recovery.fstab
@@ -16,4 +16,4 @@
 /efsg		emmc	/dev/block/bootdevice/by-name/fsg					flags=backup=1;subpartitionof=/efs1
 
 # Removable storage
-/usb_otg	vfat	/dev/block/sdg1				/dev/block/sdg			flags=display="USB-OTG";storage;wipeingui;removable
+/usbstorage      vfat    /dev/block/sdg1                            /dev/block/sdg     flags=fsflags=utf8;display="USB Storage";storage;wipeingui;removable


### PR DESCRIPTION
**Bug report**

**Issue:** USB OTG not working
**Steps to reproduce:**
1. Boot device into TWRP
2. Wait for TWRP to boot up
3. Connect USB device to the device
4. Try to mount in Mount page

**Expected outcome:** Mounts, files can be browsed in TWRP file manager
**Actual outcome**: Does not mount, files not browsable in TWRP file manager


**Fix**

See commit below.
 * Correct mount point to /usbstorage
 * Add fsflags for utf-8 encoding
 * Change display name to USB Storage
 * Change spacing / indentation
 * Add missing usbcontroller thing to BoardConfig (thanks to katinatez on XDA for pointing out)

I would recommend building the kernel from source, for that please refer to my tree.